### PR TITLE
Use orgmode.org.hyperlinks in place of orgmode.org.mappings

### DIFF
--- a/lua/orgmode-multi-key/init.lua
+++ b/lua/orgmode-multi-key/init.lua
@@ -1,10 +1,10 @@
 local M = {}
 
-local org_mappings = require('orgmode.org.mappings')
+local org_hyperlinks = require('orgmode.org.hyperlinks')
 
 -- This function will be used instead of treesitter to find links
 local is_link = function ()
-    local is_link = org_mappings._get_link_under_cursor()
+    local is_link = org_hyperlinks.get_link_under_cursor()
     if is_link == nil then
        return nil
     end


### PR DESCRIPTION
`get_link_under_cursor` was moved to `orgmode.org.hyperlinks` in nvim-orgmode/orgmode@36c76c26036f29fd2e799d3920774e9b241b0748 